### PR TITLE
Fix update customer_id update - CU-525

### DIFF
--- a/contact/serializers.py
+++ b/contact/serializers.py
@@ -7,14 +7,6 @@ class ContactSerializer(serializers.HyperlinkedModelSerializer):
     organization_uuid = serializers.ReadOnlyField()
     title_display = serializers.CharField(source='get_title_display', read_only=True)
 
-    def validate(self, attrs):
-        """Validate Uniqueness of customer_id in organization."""
-        customer_id = attrs.get('customer_id', None)
-        organization_uuid = self.context['request'].session.get('jwt_organization_uuid')
-        if customer_id and Contact.objects.filter(organization_uuid=organization_uuid, customer_id=customer_id):
-            raise serializers.ValidationError('customer_id is not unique in organization')
-        return super().validate(attrs)
-
     class Meta:
         model = Contact
         exclude = ('core_user_uuid',)

--- a/contact/tests/test_serializers.py
+++ b/contact/tests/test_serializers.py
@@ -61,26 +61,6 @@ class ContactSerializerTest(TestCase):
                                        context=serializer_context)
         self.assertEqual(serializer['title_display'].value, "Mr.")
 
-    def test_unique_customer_id_validate(self):
-        organization_uuid = uuid.uuid4()
-        mfactories.Contact(organization_uuid=organization_uuid, customer_id="abc")
-        data = {'organization_uuid': organization_uuid,
-                'customer_id': "abcd",
-                'workflowlevel1_uuids': [str(uuid.uuid4()), ]}
-        request = self.factory.get('/')
-        request.user = mfactories.User()
-        request.session = {
-            'jwt_organization_uuid': organization_uuid,
-        }
-        serializer_context = {'request': Request(request)}
-        serializer = ContactSerializer(data=data, context=serializer_context)
-        self.assertTrue(serializer.is_valid(raise_exception=True))
-        data['customer_id'] = "abc"
-        serializer = ContactSerializer(data=data, context=serializer_context)
-        self.assertFalse(serializer.is_valid())
-        with self.assertRaisesMessage(ValidationError, expected_message='customer_id is not unique in organization'):
-            serializer.is_valid(raise_exception=True)
-
 
 class ContactNameSerializerTest(TestCase):
     def setUp(self):

--- a/contact/tests/test_views.py
+++ b/contact/tests/test_views.py
@@ -653,9 +653,14 @@ class ContactUpdateViewsTest(TestCase):
     def test_update_contact(self):
         siteprofile_uuid = uuid.uuid4()
         contact = mfactories.Contact(
-            emails=[{'type': 'private', 'email': 'emil@io.io'}],
+            emails=[{
+                'type': 'private',
+                'email': 'emil@io.io',
+            }],
             organization_uuid=self.organization_uuid,
-            workflowlevel1_uuids=[self.wflvl1])
+            workflowlevel1_uuids=[self.wflvl1],
+            customer_id='123',
+        )
 
         data = {
             'first_name': 'David',
@@ -687,6 +692,7 @@ class ContactUpdateViewsTest(TestCase):
             'organization_uuid': 'ignore_this',
             'workflowlevel1_uuids': [self.wflvl1],
             'workflowlevel2_uuids': [self.wflvl2],
+            'customer_id': '123',
         }
         request = self.factory.post('', json.dumps(data),
                                     content_type='application/json')
@@ -776,6 +782,26 @@ class ContactUpdateViewsTest(TestCase):
                     'number': '67890',
                 },
             ],
+        }
+        request = self.factory.post('', data)
+        request.user = self.user
+        request.session = self.session
+        view = ContactViewSet.as_view({'post': 'update'})
+        response = view(request, pk=contact.pk)
+        self.assertEqual(response.status_code, 400)
+
+    def test_update_contact_fails_invalid_customer_id(self):
+        mfactories.Contact(
+            customer_id='123',
+            organization_uuid=self.organization_uuid,
+            workflowlevel1_uuids=[self.wflvl1])
+        contact = mfactories.Contact(
+            customer_id='124',
+            organization_uuid=self.organization_uuid,
+            workflowlevel1_uuids=[self.wflvl1])
+
+        data = {
+            'customer_id': '123',
         }
         request = self.factory.post('', data)
         request.user = self.user

--- a/crm/handlers.py
+++ b/crm/handlers.py
@@ -1,4 +1,5 @@
 from django.core.exceptions import ValidationError
+from django.db import IntegrityError
 from django.http import JsonResponse
 from rest_framework.views import exception_handler
 from rest_framework import status
@@ -8,7 +9,9 @@ def custom_exception_handler(exception, context):
     if isinstance(exception, ValidationError):
         return JsonResponse(data=exception.message_dict,
                             status=status.HTTP_400_BAD_REQUEST)
-
+    if isinstance(exception, IntegrityError):
+        return JsonResponse(data={'cause': str(exception.__cause__)},
+                            status=status.HTTP_400_BAD_REQUEST)
     # Call REST framework's default exception handler
     response = exception_handler(exception, context)
     return response


### PR DESCRIPTION
## Purpose
Update with the same customer_id was not possible.

## Approach
Having the validation at the model level with the new UniqueTogetherConstraint makes validation easier. Therefore the exception_handler was extended to have verbose error messages and some tests had to be shifted. 