### PR TITLE
Fix next customer_id from chars

### DIFF
--- a/contact/models.py
+++ b/contact/models.py
@@ -118,15 +118,19 @@ class Contact(models.Model):
     def __str__(self):
         return f"{self.first_name} {self.last_name}"
 
-    def get_default_customer_id(self):
+    def get_default_customer_id(self) -> str:
         """Figure out next free unique customer_id and return it."""
+        start_index = 10001
         try:
             latest_customer_id = self.__class__.objects.filter(
                 organization_uuid=self.organization_uuid).exclude(
                 customer_id=None).order_by('-customer_id').first().customer_id
-            next_customer_id = int(latest_customer_id) + 1
+            latest_customer_id = ''.join(x for x in latest_customer_id if x.isdigit())
+            if latest_customer_id:
+                next_customer_id = int(latest_customer_id) + 1
+            else:
+                next_customer_id = start_index
         except AttributeError:
-            start_index = 10001
             next_customer_id = start_index
         return str(next_customer_id)
 

--- a/contact/tests/test_models.py
+++ b/contact/tests/test_models.py
@@ -239,6 +239,27 @@ class ContactTest(TestCase):
         self.assertEqual(contact.customer_id, '10001')
         self.assertEqual(contact2.customer_id, '10002')
 
+    def test_next_customer_id_w_char_ids(self):
+        organization_uuid = str(uuid.uuid4())
+        Contact.objects.create(organization_uuid=organization_uuid,
+                               workflowlevel1_uuids=[str(uuid.uuid4)],
+                               customer_id='6928a')
+        contact2 = Contact.objects.create(
+            core_user_uuid=self.core_user_uuid,
+            organization_uuid=organization_uuid,
+            workflowlevel1_uuids=[str(uuid.uuid4)],
+        )
+        self.assertEqual(contact2.customer_id, '6929')
+        Contact.objects.create(organization_uuid=organization_uuid,
+                               workflowlevel1_uuids=[str(uuid.uuid4)],
+                               customer_id='no-digits')
+        contact4 = Contact.objects.create(
+            core_user_uuid=self.core_user_uuid,
+            organization_uuid=organization_uuid,
+            workflowlevel1_uuids=[str(uuid.uuid4)],
+        )
+        self.assertEqual(contact4.customer_id, '10001')
+
     def test_unique_customer_id(self):
         organization_uuid = str(uuid.uuid4())
         Contact.objects.create(organization_uuid=organization_uuid,


### PR DESCRIPTION
## Purpose
When non-numeric chars were set in the customer_id field a ValueError was raised when trying to cast to Integer.

## Approach
This Fix adds a separate casting to Integer by reading the digits from the field or resetting when no digits were found.